### PR TITLE
Fix issue with language server not working on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Language server not dowloading and running on Windows.
 
 ## [0.1.0] - 2021-05-18
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,9 +16,15 @@ import {
 let client: LanguageClient;
 
 export async function activate(context: ExtensionContext) {
+    // Note: We use the context.globalStoragePath even though it is deprecated, since
+    // the replacement globalStorageUri leads to issues when working with files on Windows
+    // (string contains drive and method calls also add drive)
+
     // Create the storage dir
-    if (!fs.existsSync(context.globalStorageUri.path)) {
-        fs.mkdirSync((context.globalStorageUri.path));
+    if (!fs.existsSync(context.globalStoragePath)) {
+        await fs.promises.mkdir(context.globalStoragePath).catch(err => {
+            window.showErrorMessage('Failed to create extension global storage directory.\n' + err);
+        });
     }
 
     // Start the language server
@@ -83,7 +89,7 @@ async function getServerExecutable(context: ExtensionContext, serverVersion: str
     const executableName = `quickbms-lsp-${serverVersion}-${getPlatformExecSuffix(process.platform)}`;
     const executableUrl = `https://github.com/ExcaliburZero/quickbms-lsp/releases/download/${serverVersion}/quickbms-lsp-` + getPlatformExecSuffix(process.platform);
 
-    const executablePath = path.join(context.globalStorageUri.path, executableName);
+    const executablePath = path.join(context.globalStoragePath, executableName);
 
     await downloadFile(`Downloading QuickBMS language server: ${executableName}`, executableUrl, executablePath);
 


### PR DESCRIPTION
Closes #1

The issue was due to `context.globalStorageUri.path` including the drive `C:` on Windows and the functions related to files also adding `C:`, resulting in it attempting to work with paths like `C:C:/mypathhere` which always failed.

To fix this I changed usages of `context.globalStorageUri.path` to the deprecated but functional `context.globalStoragePath`.